### PR TITLE
Allow multi-touch glis using pointer events.

### DIFF
--- a/src/Key.js
+++ b/src/Key.js
@@ -95,6 +95,9 @@ class Key extends React.Component {
         onMouseUp={useTouchEvents ? null : this.onStopNoteInput}
         onMouseEnter={gliss ? this.onPlayNoteInput : null}
         onMouseLeave={this.onStopNoteInput}
+        onPointerDown={useTouchEvents ? (ev) => { ev.target.releasePointerCapture(ev.pointerId); } : null}
+        onPointerEnter={useTouchEvents ? this.onPlayNoteInput : null}
+        onPointerLeave={useTouchEvents ? this.onStopNoteInput : null}
         onTouchStart={useTouchEvents ? this.onPlayNoteInput : null}
         onTouchCancel={useTouchEvents ? this.onStopNoteInput : null}
         onTouchEnd={useTouchEvents ? this.onStopNoteInput : null}


### PR DESCRIPTION
Hello Kevin,

Thanks for this great project. This small patch adds the ability for multi-touch glis using the pointer-events API. That means you can wiggle around on multiple notes using multiple fingers and they will fire off correctly. You can test this by loading your demos up on a touch device and swiping over multiple keys (it helps to have some CSS to stop the page scrolling when you do this).

I found the `releasePointerCapture` trick here: https://stackoverflow.com/a/57046105

Let me know if there are any changes you want me to make. Thanks again.